### PR TITLE
Fix object id filter parameter for log entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "starkbank",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha tests --timeout 20000"
   },
   "repository": {
     "type": "git",

--- a/sdk/boleto/log/log.js
+++ b/sdk/boleto/log/log.js
@@ -53,7 +53,7 @@ exports.get = async function (id, {user} = {}) {
     return rest.getId(resource, id, user);
 };
 
-exports.query = async function ({limit, status, tags, ids, after, before, user} = {}) {
+exports.query = async function ({limit, types, boletoIds, after, before, user} = {}) {
     /**
      *
      * Retrieve Boleto Logs
@@ -62,7 +62,7 @@ exports.query = async function ({limit, status, tags, ids, after, before, user} 
      *
      * Parameters (optional):
      * limit [integer, default None]: maximum number of objects to be retrieved. Unlimited if None. ex: 35
-     * boleto_ids [list of strings, default None]: list of Boleto ids to filter logs. ex: ['5656565656565656', '4545454545454545']
+     * boletoIds [list of strings, default None]: list of Boleto ids to filter logs. ex: ['5656565656565656', '4545454545454545']
      * types [list of strings, default None]: filter for log event types. ex: 'paid' or 'registered'
      * after [string, default None] date filter for objects created only after specified date. ex: '2020-03-10'
      * before [string, default None] date filter for objects only before specified date. ex: '2020-03-10'
@@ -74,9 +74,8 @@ exports.query = async function ({limit, status, tags, ids, after, before, user} 
      */
     let query = {
         limit: limit,
-        status: status,
-        tags: tags,
-        ids: ids,
+        types: types,
+        boletoIds: boletoIds,
         after: after,
         before: before,
     };

--- a/sdk/boletoPayment/log/log.js
+++ b/sdk/boletoPayment/log/log.js
@@ -52,7 +52,7 @@ exports.get = async function (id, {user} = {}) {
     return rest.getId(resource, id, user);
 };
 
-exports.query = async function ({limit, status, tags, ids, after, before, user} = {}) {
+exports.query = async function ({limit, types, paymentIds, after, before, user} = {}) {
     /**
      *
      * Retrieve BoletoPayment Logs
@@ -61,7 +61,7 @@ exports.query = async function ({limit, status, tags, ids, after, before, user} 
      *
      * Parameters (optional):
      * limit [integer, default None]: maximum number of objects to be retrieved. Unlimited if None. ex: 35
-     * payment_ids [list of strings, default None]: list of BoletoPayment ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
+     * paymentIds [list of strings, default None]: list of BoletoPayment ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
      * types [list of strings, default None]: filter retrieved objects by event types. ex: 'paid' or 'registered'
      * user [Project object, default None]: Project object. Not necessary if starkbank.user was set before function call
      *
@@ -71,9 +71,8 @@ exports.query = async function ({limit, status, tags, ids, after, before, user} 
      */
     let query = {
         limit: limit,
-        status: status,
-        tags: tags,
-        ids: ids,
+        types: types,
+        paymentIds: paymentIds,
         after: after,
         before: before,
     };

--- a/sdk/boletoPayment/log/log.js
+++ b/sdk/boletoPayment/log/log.js
@@ -63,6 +63,8 @@ exports.query = async function ({limit, types, paymentIds, after, before, user} 
      * limit [integer, default None]: maximum number of objects to be retrieved. Unlimited if None. ex: 35
      * paymentIds [list of strings, default None]: list of BoletoPayment ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
      * types [list of strings, default None]: filter retrieved objects by event types. ex: 'paid' or 'registered'
+     * after [string, default None] date filter for objects created only after specified date. ex: '2020-03-10'
+     * before [string, default None] date filter for objects only before specified date. ex: '2020-03-10'
      * user [Project object, default None]: Project object. Not necessary if starkbank.user was set before function call
      *
      * Return:

--- a/sdk/transfer/log/log.js
+++ b/sdk/transfer/log/log.js
@@ -51,7 +51,7 @@ exports.get = async function (id, {user} = {}) {
     return rest.getId(resource, id, user);
 };
 
-exports.query = async function ({limit, status, tags, ids, after, before, user} = {}) {
+exports.query = async function ({limit, types, transferIds, after, before, user} = {}) {
     /**
      *
      * Retrieve Transfer Logs
@@ -60,7 +60,7 @@ exports.query = async function ({limit, status, tags, ids, after, before, user} 
      *
      * Parameters (optional):
      * limit [integer, default None]: maximum number of objects to be retrieved. Unlimited if None. ex: 35
-     * transfer_ids [list of strings, default None]: list of Transfer ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
+     * transferIds [list of strings, default None]: list of Transfer ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
      * types [list of strings, default None]: filter retrieved objects by types. ex: 'success' or 'failed'
      * after [string, default None] date filter for objects created only after specified date. ex: '2020-03-10'
      * before [string, default None] date filter for objects only before specified date. ex: '2020-03-10'
@@ -72,9 +72,8 @@ exports.query = async function ({limit, status, tags, ids, after, before, user} 
      */
     let query = {
         limit: limit,
-        status: status,
-        tags: tags,
-        ids: ids,
+        types: types,
+        transferIds: transferIds,
         after: after,
         before: before,
     };

--- a/sdk/utilityPayment/log/log.js
+++ b/sdk/utilityPayment/log/log.js
@@ -51,7 +51,7 @@ exports.get = async function (id, {user} = {}) {
     return rest.getId(resource, id, user);
 };
 
-exports.query = async function ({limit = null, status = null, tags = null, paymentIds = null, after = null, before = null, user = null} = {}) {
+exports.query = async function ({limit, types, paymentIds, after, before, user} = {}) {
     /**
      *
      * Retrieve UtilityPayment Logs
@@ -60,8 +60,10 @@ exports.query = async function ({limit = null, status = null, tags = null, payme
      *
      * Parameters (optional):
      * limit [integer, default None]: maximum number of objects to be retrieved. Unlimited if None. ex: 35
-     * payment_ids [list of strings, default None]: list of UtilityPayment ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
+     * paymentIds [list of strings, default None]: list of UtilityPayment ids to filter retrieved objects. ex: ['5656565656565656', '4545454545454545']
      * types [list of strings, default None]: filter retrieved objects by event types. ex: 'paid' or 'registered'
+     * after [string, default None] date filter for objects created only after specified date. ex: '2020-03-10'
+     * before [string, default None] date filter for objects only before specified date. ex: '2020-03-10'
      * user [Project object, default None]: Project object. Not necessary if starkbank.user was set before function call
      *
      * Return:
@@ -70,8 +72,7 @@ exports.query = async function ({limit = null, status = null, tags = null, payme
      */
     let query = {
         limit: limit,
-        status: status,
-        tags: tags,
+        types: types,
         paymentIds: paymentIds,
         after: after,
         before: before,

--- a/tests/testBoletoPaymentLog.js
+++ b/tests/testBoletoPaymentLog.js
@@ -35,21 +35,19 @@ describe('TestBoletoPaymentLogGet', () => {
             makeBoleto("Beltrano da Silta", 10000),
         ])
 
-        const tomorrow = new Date()
-        tomorrow.setDate(tomorrow.getDate() + 1)
-        const scheduled = tomorrow.toISOString().substring(0, 10)
+        const tomorrow = futureDate(1)
 
         let [payment1, payment2] = await starkbank.boletoPayment.create([
             {
                 taxId: boleto1.taxId,
                 description: `Payment to ${boleto1.name}`,
-                scheduled: scheduled,
+                scheduled: tomorrow,
                 line: boleto1.line,
             },
             {
                 taxId: boleto2.taxId,
                 description: `Payment to ${boleto2.name}`,
-                scheduled: scheduled,
+                scheduled: tomorrow,
                 line: boleto2.line,
             }
         ]);

--- a/tests/utils/random.js
+++ b/tests/utils/random.js
@@ -6,5 +6,6 @@ exports.randomInt = function (min, max) {
 
 exports.futureDate = function (number) {
     let date = new Date();
-    return date.setDate(date.getDate() + number);
+    date.setDate(date.getDate() + number);
+    return date.toISOString().substring(0, 10);
 };


### PR DESCRIPTION
This fixes:

paymentIds for boletoPayments.log.query()
paymentIds for utilityPayments.log.query()
transferIds for transfer.log.query()
boletoIds for boleto.log.query()