### PR TITLE
Fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -210,8 +210,7 @@
     "decamelize": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
     },
     "define-properties": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   },
   "homepage": "https://github.com/starkbank/ecdsa-node#readme",
   "dependencies": {
-    "starkbank-ecdsa": "^1.1.2",
-    "axios": "^0.19.2"
+    "axios": "^0.19.2",
+    "decamelize": "^4.0.0",
+    "starkbank-ecdsa": "^1.1.2"
   },
   "devDependencies": {
-    "decamelize": "^4.0.0",
     "mocha": "^7.1.2"
   }
 }


### PR DESCRIPTION
This PR moves `decamelize` to the production dependencies. 
Without this change, we are getting the following error:

```sh
Error: Cannot find module 'decamelize'
Require stack:
- /var/task/node_modules/starkbank/sdk/utils/api.js
- /var/task/node_modules/starkbank/sdk/utils/rest.js
- /var/task/node_modules/starkbank/sdk/transaction/transaction.js
- /var/task/node_modules/starkbank/sdk/transaction/index.js
- /var/task/node_modules/starkbank/index.js
```