### PR TITLE
Default to Use starkBank.user when verifying signature.

### DIFF
--- a/sdk/event/event.js
+++ b/sdk/event/event.js
@@ -37,7 +37,7 @@ class Event extends Resource {
 exports.Event = Event;
 let resource = {'class': exports.Event, 'name': 'Event'};
 
-async function verifySignature(content, signature, user = null, refresh = false) {
+async function verifySignature(content, signature, user = starkBank.user, refresh = false) {
     let publicKey = starkbank.cache['starkbank-public-key'];
     if (!publicKey || refresh) {
         let pem = await rest.getPublicKey(user);


### PR DESCRIPTION
Hi, I'm not entirely sure if this is the correct fix but while using the SDK I had an issue when consuming webhook events.

It does not seem correct to set it to `null` because the user is needed for getting the public key.

```ts
getPublicKey = async function (user = starkBank.user) 
```

Consider the following please

> JavaScript Default Parameters with null or empty Argument
If we do not provide any value for the function parameter then the default value is used, but what if someone provides null or an empty string as value. In that case null and empty value is considered valid and default parameter value is not used.