### PR TITLE
fix(types): correct invoice log param and utilityPayment id type

### DIFF
--- a/types/invoice/invoice.d.ts
+++ b/types/invoice/invoice.d.ts
@@ -359,7 +359,7 @@ declare module 'starkbank' {
                 after?: string | null, 
                 before?: string | null, 
                 types?: string[] | null, 
-                paymentIds?: string[] | null, 
+                invoiceIds?: string[] | null, 
                 user?: Project | Organization | null
             }): Promise<[invoice.Log[], string | null]>;
 
@@ -404,7 +404,7 @@ declare module 'starkbank' {
                 after?: string | null, 
                 before?: string | null, 
                 types?: string[] | null, 
-                paymentIds?: string[] | null, 
+                invoiceIds?: string[] | null, 
                 user?: Project | Organization | null
             }): Promise<invoice.Log[]>;
         }

--- a/types/utilityPayment/utilityPayment.d.ts
+++ b/types/utilityPayment/utilityPayment.d.ts
@@ -41,7 +41,7 @@ declare module 'starkbank' {
         line?: string | null
         barCode?: string | null
 
-        readonly id?: string | null
+        readonly id: string
         readonly status?: string | null
         readonly amount?: number | null
         readonly fee?: number | null


### PR DESCRIPTION
## Description

Two TypeScript type definition fixes found while reviewing the SDK.

### 1. `invoice.log.query()` and `invoice.log.page()` use wrong param name (#114)

The type definitions use `paymentIds` in the function signature, but the JS runtime destructures `invoiceIds`. TypeScript users passing `paymentIds` would have their filter silently ignored — the value goes nowhere.

The JSDoc `@param` already correctly says `invoiceIds`, so this was a copy-paste mistake from other payment-type log modules (which correctly use `paymentIds` for their domain).

### 2. `UtilityPayment.id` should not be optional (#113)

```typescript
// Before:
readonly id?: string | null

// After:
readonly id: string
```

The `id` is always returned by the API for existing payments. Having it as `string | null | undefined` forces unnecessary null checks on users who retrieve payments. The constructor still accepts `id?: string | null` for creation scenarios.

## Testing

- No runtime changes — only TypeScript type definitions were updated
- `npm test` (mocha) passes
- `npm run test:typescript` (jest) passes

Closes #113
Closes #114