### PR TITLE
fix(event): support both positional and object args in parse()

### DIFF
--- a/sdk/event/event.js
+++ b/sdk/event/event.js
@@ -168,7 +168,7 @@ exports.update = async function (id, {isDelivered, user} = {}) {
     return rest.patchId(resource, id, payload, user);
 };
 
-exports.parse = async function ({content, signature, user} = {}) {
+exports.parse = async function (content, signature, user) {
     /**
      *
      * Create single notification Event from a content string
@@ -188,6 +188,17 @@ exports.parse = async function ({content, signature, user} = {}) {
      * @returns Event object with updated attributes
      *
      */
+
+    if (typeof content === 'object' && content !== null && !Array.isArray(content)) {
+        ({content, signature, user} = content);
+    }
+
+    if (typeof content !== 'string' || content.length === 0) {
+        throw new Error('content must be a non-empty JSON string');
+    }
+    if (typeof signature !== 'string' || signature.length === 0) {
+        throw new Error('signature must be a non-empty base-64 string');
+    }
 
     let event = Object.assign(new Event(), JSON.parse(content)['event']);
     try {


### PR DESCRIPTION
## Bug

`event.parse()` only accepted a single object parameter via destructuring:

```js
parse({content, signature, user})
```

But the JSDoc documents positional parameters:

```js
parse(content, signature, user)
```

When users follow the docs and call `parse(content, signature)`, destructuring the content string yields `undefined` for all values, causing `JSON.parse(undefined)` → `SyntaxError: Unexpected token u in JSON at position 0`.

## Fix

1. Check if first arg is a plain object → destructure; otherwise treat as positional
2. Add input validation: throw clear error if content/signature are missing

Closes #163